### PR TITLE
break loop if can't find object

### DIFF
--- a/JSONTools/JSONPatch.m
+++ b/JSONTools/JSONPatch.m
@@ -35,6 +35,11 @@
         NSInteger t = 1;
         
         while (YES) {
+            // path not found, fail this
+            if (!object || [object isKindOfClass:NSNull.class]) {
+                result = @(0);
+                break;
+            }
             if (![object isKindOfClass:[NSMutableDictionary class]] &&
                 ![object isKindOfClass:[NSMutableArray class]] &&
                 [object respondsToSelector:@selector(mutableCopy)])


### PR DESCRIPTION
Infinite loop when the patches array contained an invalid JSON path
